### PR TITLE
setup.py: Declare extras for the supported backends

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,10 @@ setup(
         'Programming Language :: Python',
         'Topic :: Scientific/Engineering :: Mathematics',
         ],
+    extras_require={
+        'cypari':      ['cypari'],
+        'cypari2':     ['cypari2'],
+        'passagemath': ['passagemath-pari'],
+    }
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ deps =
     pytest-cov
     cypari: cypari
     cypari2: cypari2
+extras =
+    passagemath: passagemath
 commands =
     py.test {posargs}
 


### PR DESCRIPTION
In addition to "cypari" and "cypari2", this declares an extra "passagemath", which pulls in the distribution https://pypi.org/project/passagemath-pari/ (which vendors a version of cypari2).