### PR TITLE
pyproject.toml: New

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "setuptools>=64",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This adds a minimal `pyproject.toml` file, to avoid warnings such as "DEPRECATION: Building 'realalg' using the legacy setup.py bdist_wheel mechanism, which will be removed in a future version. pip 25.3 will enforce this behaviour change."