### PR TITLE
When both are present, use the `cypari2` backend rather than `cypari`.

### DIFF
--- a/realalg/__init__.py
+++ b/realalg/__init__.py
@@ -14,7 +14,6 @@ for interface in INTERFACES:
         RealNumberField = module.RealNumberField
         RealAlgebraic = module.RealAlgebraic
         eigenvectors = module.eigenvectors
-        print(f'Using {interface}')
         break
         # We could add some code here to find out which interface was loaded.
     except ImportError:

--- a/realalg/__init__.py
+++ b/realalg/__init__.py
@@ -14,6 +14,7 @@ for interface in INTERFACES:
         RealNumberField = module.RealNumberField
         RealAlgebraic = module.RealAlgebraic
         eigenvectors = module.eigenvectors
+        print(f'Using {interface}')
         break
         # We could add some code here to find out which interface was loaded.
     except ImportError:

--- a/realalg/__init__.py
+++ b/realalg/__init__.py
@@ -7,7 +7,7 @@ __version__ = importlib.metadata.version('realalg')
 
 # from .algebraic import RealNumberField, RealAlgebraic  # noqa: F401
 
-INTERFACES = ['cypari', 'cypari2', 'sympy']
+INTERFACES = ['cypari2', 'cypari', 'sympy']
 for interface in INTERFACES:
     try:
         module = import_module(f'realalg.{interface}_algebraic')

--- a/realalg/base_algebraic.py
+++ b/realalg/base_algebraic.py
@@ -39,7 +39,7 @@ class BaseRealNumberField:
             raise ValueError(f'Polynomial {self.sp_polynomial} has no real roots')
         self.sp_place = real_roots[index]
         self._accuracy = 0
-        self._intervals = None
+        self._intervals = dict()
         self.lmbda = None  # To be created by instances.
     
     def __str__(self):
@@ -52,19 +52,23 @@ class BaseRealNumberField:
         return (self.__class__, (self.coefficients,))
     def __eq__(self, other):
         return self.coefficients == other.coefficients and self.index == other.index
+    def find_root_as_interval(self, precision):
+        s = str(sp.N(self.sp_place, precision))
+        return Interval.from_string(s, precision)
     
     def intervals(self, accuracy):
         ''' Return intervals around self.lmbda**i with at least the requested accuracy. '''
         assert isinstance(accuracy, Integral)
         assert accuracy > 0
-        if accuracy > self._accuracy:
+        if accuracy not in self._intervals:
             precision = int(accuracy + self.degree*self.log_bound + 1) + 1  # Cheap ceil.
-            s = str(sp.N(self.sp_place, precision))
-            interval = Interval.from_string(s, precision)
-            self._intervals = [interval**i for i in range(self.degree)]
-            assert all(I.accuracy >= accuracy for I in self._intervals)
-            self._accuracy = accuracy
-        return [I.simplify(accuracy+1) for I in self._intervals]
+            interval = self.find_root_as_interval(precision)
+            intervals = [interval**i for i in range(self.degree)]
+            assert all(I.accuracy >= accuracy for I in intervals)
+            invervals = [I.simplify(accuracy+1) for I in intervals]
+            self._intervals[accuracy] = intervals
+            self._accuracy = max(accuracy, self._accuracy)
+        return self._intervals[accuracy]
 
 @total_ordering
 class BaseRealAlgebraic(ABC):

--- a/realalg/base_algebraic.py
+++ b/realalg/base_algebraic.py
@@ -8,6 +8,13 @@ from math import log10 as log
 from numbers import Integral
 import sympy as sp
 
+# By default, Python will only convert a decimal string of length at
+# most 4300 to an intger, to protect against DDOS attacks not relevant
+# here (CVE-2020-10735).
+import sys
+if hasattr(sys, 'set_int_max_str_digits'):
+    sys.set_int_max_str_digits(0)
+
 from .interval import Interval
 
 sp_x = sp.Symbol('x')

--- a/realalg/cypari2_algebraic.py
+++ b/realalg/cypari2_algebraic.py
@@ -18,6 +18,7 @@ class RealNumberField(BaseRealNumberField):
     __engine = 'cypari2'
     
     def __init__(self, coefficients, index=-1):  # List of integers and / or Fractions, integer index
+        print(coefficients, index)
         super().__init__(coefficients, index)
         self.cp_polynomial = cp_polynomial(self.coefficients)
         self.lmbda = self([0, 1])

--- a/realalg/cypari2_algebraic.py
+++ b/realalg/cypari2_algebraic.py
@@ -5,6 +5,7 @@ from fractions import Fraction
 import numpy as np
 import cypari2  # pylint: disable=import-error
 from .base_algebraic import BaseRealNumberField, BaseRealAlgebraic
+from .interval import Interval
 
 cp = cypari2.Pari()
 cp_x = cp('x')
@@ -18,10 +19,18 @@ class RealNumberField(BaseRealNumberField):
     __engine = 'cypari2'
     
     def __init__(self, coefficients, index=-1):  # List of integers and / or Fractions, integer index
-        print(coefficients, index)
         super().__init__(coefficients, index)
         self.cp_polynomial = cp_polynomial(self.coefficients)
         self.lmbda = self([0, 1])
+
+    def find_root_as_interval(self, precision):
+        bit_prec = int(3.32192809488737 * precision) + 1
+        old_bit_prec = cp.get_real_precision_bits()
+        cp.set_real_precision_bits(bit_prec)
+        roots = list(self.cp_polynomial.polrootsreal(precision=bit_prec))
+        s = str(roots[self.index])
+        cp.set_real_precision_bits(old_bit_prec)
+        return Interval.from_string(s, precision)
     
     def __call__(self, coefficients):
         return RealAlgebraic(self, cp_polynomial(coefficients).Mod(self.cp_polynomial))

--- a/realalg/cypari_algebraic.py
+++ b/realalg/cypari_algebraic.py
@@ -5,6 +5,8 @@ from fractions import Fraction
 import numpy as np
 import cypari  # pylint: disable=import-error
 from .base_algebraic import BaseRealNumberField, BaseRealAlgebraic
+from .interval import Interval
+
 
 cp = cypari.pari
 cp_x = cp('x')
@@ -21,6 +23,15 @@ class RealNumberField(BaseRealNumberField):
         super().__init__(coefficients, index)
         self.cp_polynomial = cp_polynomial(self.coefficients)
         self.lmbda = self([0, 1])
+
+    def find_root_as_interval(self, precision):
+        bit_prec = int(3.32192809488737 * precision) + 1
+        old_bit_prec = cp.get_real_precision_bits()
+        cp.set_real_precision_bits(bit_prec)
+        roots = list(self.cp_polynomial.polrootsreal(precision=bit_prec))
+        s = str(roots[self.index])
+        cp.set_real_precision_bits(old_bit_prec)
+        return Interval.from_string(s, precision)
     
     def __call__(self, coefficients):
         return RealAlgebraic(self, cp_polynomial(coefficients).Mod(self.cp_polynomial))

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def readme():
 
 setup(
     name='realalg',
-    version='0.3.6',
+    version='0.3.7',
     description='For manipulating real algebraic numbers',
     long_description=readme(),
     author='Mark Bell',


### PR DESCRIPTION
Previously, the cypari backend was used which can result in conflicts between the two packages resulting in a hard SIGABRT crash.  For example, this happens with [flipper_pari_crash_boiled.py](https://github.com/user-attachments/files/28400273/flipper_pari_crash_boiled.py) on macOS using SageMath 10.8 when `cypari==2.5.6` is also installed, resulting in the following traceback:
```
$ sage -python  flipper_pari_crash_boiled.py
  ***   Warning: increasing stack size to 8011776.
------------------------------------------------------------------------
0   signals.cpython-313-darwin.so       0x00000001063b27e4 PyInit_signals + 23656
1   signals.cpython-313-darwin.so       0x00000001063b2634 PyInit_signals + 23224
2   libsystem_platform.dylib            0x000000019dc056a4 _sigtramp + 56
3   libsystem_pthread.dylib             0x000000019dbcb848 pthread_kill + 296
4   libsystem_c.dylib                   0x000000019dad4a2c abort + 124
5   _pari.cpython-313-darwin.so         0x00000001075a28e8 __pyx_f_6cypari_5_pari__pari_err_recover + 28
6   _pari.cpython-313-darwin.so         0x0000000107ec12e4 pari_err + 440
7   _pari.cpython-313-darwin.so         0x0000000107ec58c4 gcopy + 812
8   _pari.cpython-313-darwin.so         0x0000000107ec5864 gcopy + 716
9   _pari.cpython-313-darwin.so         0x0000000107ec5864 gcopy + 716
10  _pari.cpython-313-darwin.so         0x000000010798d464 ker_aux + 1512
11  _pari.cpython-313-darwin.so         0x000000010798cc40 ker + 840
12  _pari.cpython-313-darwin.so         0x0000000107653108 __pyx_pf_6cypari_5_pari_8Gen_base_976matker + 124
13  _pari.cpython-313-darwin.so         0x00000001075eafe4 __pyx_pw_6cypari_5_pari_8Gen_base_977matker + 504
14  python3.13                          0x0000000104f9076c PyObject_Vectorcall + 88
15  python3.13                          0x00000001050be2d0 _PyEval_EvalFrameDefault + 7000
16  python3.13                          0x0000000104faa1d8 PyAsyncGen_New + 2740
17  python3.13                          0x0000000104fa8c08 _PyGen_FetchStopIterationValue + 904
18  python3.13                          0x0000000104fbcce0 _PyList_FromArraySteal + 8036
19  python3.13                          0x0000000104fbb9b8 _PyList_FromArraySteal + 3132
20  python3.13                          0x0000000104f9076c PyObject_Vectorcall + 88
21  python3.13                          0x00000001050be2d0 _PyEval_EvalFrameDefault + 7000
22  python3.13                          0x00000001050bc240 PyEval_EvalCode + 252
23  python3.13                          0x0000000105129b5c PyRun_InteractiveLoop + 1192
24  python3.13                          0x0000000105129828 PyRun_InteractiveLoop + 372
25  python3.13                          0x0000000105126c5c PyErr_Print + 1500
26  python3.13                          0x0000000105126610 _PyThreadState_PopFrame + 372
27  python3.13                          0x000000010514c1cc Py_BytesMain + 1188
28  python3.13                          0x000000010514ba38 Py_RunMain + 1516
29  python3.13                          0x000000010514bcb0 Py_Main + 372
30  python3.13                          0x000000010514bd50 Py_BytesMain + 40
31  dyld                                0x000000019d82ab98 start + 6076
------------------------------------------------------------------------
Unhandled SIGABRT: An abort() occurred.
This probably occurred because a *compiled* module has a bug
in it and is not properly wrapped with sig_on(), sig_off().
Python will now terminate.
------------------------------------------------------------------------
/usr/local/bin/sage: line 39: 53318 Abort trap: 6           /usr/bin/env PYTHONUSERBASE="$USERBASE" SSL_CERT_FILE="$SSL_CERT_FILE" "$SYMLINK"/venv/bin/sage "$@"
```
