### PR TITLE
When both are present, use the `cypari2` backend rather than `cypari`.

### DIFF
--- a/realalg/__init__.py
+++ b/realalg/__init__.py
@@ -7,7 +7,7 @@ __version__ = importlib.metadata.version('realalg')
 
 # from .algebraic import RealNumberField, RealAlgebraic  # noqa: F401
 
-INTERFACES = ['cypari', 'cypari2', 'sympy']
+INTERFACES = ['cypari2', 'cypari', 'sympy']
 for interface in INTERFACES:
     try:
         module = import_module(f'realalg.{interface}_algebraic')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def readme():
 
 setup(
     name='realalg',
-    version='0.3.6',
+    version='0.3.7',
     description='For manipulating real algebraic numbers',
     long_description=readme(),
     author='Mark Bell',


### PR DESCRIPTION
Previously, the cypari backend was used which can result in conflicts between the two packages resulting in a hard SIGABRT crash.  For example, this happens with [flipper_pari_crash_boiled.py](https://github.com/user-attachments/files/28400273/flipper_pari_crash_boiled.py) on macOS using SageMath 10.8 when `cypari==2.5.6` is also installed, resulting in the following traceback:
```
$ sage -python  flipper_pari_crash_boiled.py
  ***   Warning: increasing stack size to 8011776.
------------------------------------------------------------------------
0   signals.cpython-313-darwin.so       0x00000001063b27e4 PyInit_signals + 23656
1   signals.cpython-313-darwin.so       0x00000001063b2634 PyInit_signals + 23224
2   libsystem_platform.dylib            0x000000019dc056a4 _sigtramp + 56
3   libsystem_pthread.dylib             0x000000019dbcb848 pthread_kill + 296
4   libsystem_c.dylib                   0x000000019dad4a2c abort + 124
5   _pari.cpython-313-darwin.so         0x00000001075a28e8 __pyx_f_6cypari_5_pari__pari_err_recover + 28
6   _pari.cpython-313-darwin.so         0x0000000107ec12e4 pari_err + 440
7   _pari.cpython-313-darwin.so         0x0000000107ec58c4 gcopy + 812
8   _pari.cpython-313-darwin.so         0x0000000107ec5864 gcopy + 716
9   _pari.cpython-313-darwin.so         0x0000000107ec5864 gcopy + 716
10  _pari.cpython-313-darwin.so         0x000000010798d464 ker_aux + 1512
11  _pari.cpython-313-darwin.so         0x000000010798cc40 ker + 840
12  _pari.cpython-313-darwin.so         0x0000000107653108 __pyx_pf_6cypari_5_pari_8Gen_base_976matker + 124
13  _pari.cpython-313-darwin.so         0x00000001075eafe4 __pyx_pw_6cypari_5_pari_8Gen_base_977matker + 504
14  python3.13                          0x0000000104f9076c PyObject_Vectorcall + 88
15  python3.13                          0x00000001050be2d0 _PyEval_EvalFrameDefault + 7000
16  python3.13                          0x0000000104faa1d8 PyAsyncGen_New + 2740
17  python3.13                          0x0000000104fa8c08 _PyGen_FetchStopIterationValue + 904
18  python3.13                          0x0000000104fbcce0 _PyList_FromArraySteal + 8036
19  python3.13                          0x0000000104fbb9b8 _PyList_FromArraySteal + 3132
20  python3.13                          0x0000000104f9076c PyObject_Vectorcall + 88
21  python3.13                          0x00000001050be2d0 _PyEval_EvalFrameDefault + 7000
22  python3.13                          0x00000001050bc240 PyEval_EvalCode + 252
23  python3.13                          0x0000000105129b5c PyRun_InteractiveLoop + 1192
24  python3.13                          0x0000000105129828 PyRun_InteractiveLoop + 372
25  python3.13                          0x0000000105126c5c PyErr_Print + 1500
26  python3.13                          0x0000000105126610 _PyThreadState_PopFrame + 372
27  python3.13                          0x000000010514c1cc Py_BytesMain + 1188
28  python3.13                          0x000000010514ba38 Py_RunMain + 1516
29  python3.13                          0x000000010514bcb0 Py_Main + 372
30  python3.13                          0x000000010514bd50 Py_BytesMain + 40
31  dyld                                0x000000019d82ab98 start + 6076
------------------------------------------------------------------------
Unhandled SIGABRT: An abort() occurred.
This probably occurred because a *compiled* module has a bug
in it and is not properly wrapped with sig_on(), sig_off().
Python will now terminate.
------------------------------------------------------------------------
/usr/local/bin/sage: line 39: 53318 Abort trap: 6           /usr/bin/env PYTHONUSERBASE="$USERBASE" SSL_CERT_FILE="$SSL_CERT_FILE" "$SYMLINK"/venv/bin/sage "$@"
```
