### PR TITLE
Python will not convert long decimal strings to integers by default

### DIFF
--- a/realalg/base_algebraic.py
+++ b/realalg/base_algebraic.py
@@ -8,6 +8,13 @@ from math import log10 as log
 from numbers import Integral
 import sympy as sp
 
+# By default, Python will only convert a decimal string of length at
+# most 4300 to an intger, to protect against DDOS attacks not relevant
+# here (CVE-2020-10735).
+import sys
+if hasattr(sys, 'set_int_max_str_digits'):
+    sys.set_int_max_str_digits(0)
+
 from .interval import Interval
 
 sp_x = sp.Symbol('x')

--- a/realalg/base_algebraic.py
+++ b/realalg/base_algebraic.py
@@ -6,20 +6,21 @@ from fractions import Fraction
 from functools import total_ordering
 from math import log10 as log
 from numbers import Integral
-import sympy as sp
-
-# By default, Python will only convert a decimal string of length at
-# most 4300 to an intger, to protect against DDOS attacks not relevant
-# here (CVE-2020-10735).
 import sys
-if hasattr(sys, 'set_int_max_str_digits'):
-    sys.set_int_max_str_digits(0)
+
+import sympy as sp
 
 from .interval import Interval
 
 sp_x = sp.Symbol('x')
 sp_QQ_x = sp.QQ.old_poly_ring(sp_x)
 LOG_2 = log(2)
+
+# By default, Python will only convert a decimal string of length at
+# most 4300 to an integer to protect against DDOS attacks; not relevant
+# here (CVE-2020-10735).
+if hasattr(sys, 'set_int_max_str_digits'):
+    sys.set_int_max_str_digits(0)
 
 def log_plus(x):
     ''' Return the height of the number ``x``. '''


### PR DESCRIPTION
By default, Python will only convert a decimal string of length at most 4300 to an integer, to protect against DDOS attacks not relevant here (CVE-2020-10735).  As flipper can create larger integers than that, we remove this limitation (as SageMath does).